### PR TITLE
[#180] 비회원 주문 오류 수정

### DIFF
--- a/src/main/java/com/nhnacademy/inkbridge/front/adaptor/impl/OrderAdaptorImpl.java
+++ b/src/main/java/com/nhnacademy/inkbridge/front/adaptor/impl/OrderAdaptorImpl.java
@@ -256,7 +256,7 @@ public class OrderAdaptorImpl implements OrderAdaptor {
         HttpEntity<Void> entity = new HttpEntity<>(createHeader());
 
         ResponseEntity<BookOrderViewResponseDto> exchange = restTemplate.exchange(
-            gatewayProperties.getUrl() + "/api/auth/orders/{orderCode}",
+            gatewayProperties.getUrl() + "/api/orders/{orderCode}",
             HttpMethod.GET,
             entity,
             new ParameterizedTypeReference<>() {

--- a/src/main/java/com/nhnacademy/inkbridge/front/controller/AnonymousOrderController.java
+++ b/src/main/java/com/nhnacademy/inkbridge/front/controller/AnonymousOrderController.java
@@ -6,6 +6,7 @@ import com.nhnacademy.inkbridge.front.dto.order.BookOrderViewResponseDto;
 import com.nhnacademy.inkbridge.front.service.OrderService;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping("/anonymous-orders")
 @RequiredArgsConstructor
+@Slf4j
 public class AnonymousOrderController {
 
     private final OrderService orderService;
@@ -38,6 +40,8 @@ public class AnonymousOrderController {
     public String orderDetailView(@PathVariable("orderCode") String orderCode, Model model) {
 
         BookOrderViewResponseDto response = orderService.getOrderInfoByOrderCode(orderCode);
+
+        log.debug("anonymous order view start");
 
         model.addAttribute("order", response);
 

--- a/src/main/java/com/nhnacademy/inkbridge/front/service/impl/PayServiceImpl.java
+++ b/src/main/java/com/nhnacademy/inkbridge/front/service/impl/PayServiceImpl.java
@@ -1,7 +1,5 @@
 package com.nhnacademy.inkbridge.front.service.impl;
 
-import static com.nhnacademy.inkbridge.front.utils.CommonUtils.getMemberId;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nhnacademy.inkbridge.front.adaptor.PayAdaptor;
@@ -24,6 +22,7 @@ import com.nhnacademy.inkbridge.front.utils.CookieUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -58,15 +57,14 @@ public class PayServiceImpl implements PayService {
         PayConfirmResponseDto responseDto = doConfirm(requestDto, provider);
         registerPay(responseDto);
 
-        String memberId = Objects.isNull(getMemberId()) ? CookieUtils.getCookie("cart").getValue()
-            : getMemberId().toString();
+        Cookie cartId = CookieUtils.getCookie("cart");
 
-        if (Objects.nonNull(memberId)) {
+        if (Objects.nonNull(cartId)) {
             List<OrderBooksIdResponseDto> bookIdResponseDtoList =
                 orderService.getOrderBookIds(requestDto.getOrderId());
 
             bookIdResponseDtoList.forEach(
-                book -> cartService.deleteCartBook(book.getBookId().toString(), memberId));
+                book -> cartService.deleteCartBook(book.getBookId().toString(), cartId.getValue()));
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,5 +18,5 @@ secure-key-manager.url=https://api-keymanager.nhncloudservice.com
 secure-key-manager.path=/keymanager/v1.0/appkey/{appkey}/secrets/{keyid}
 secure-key-manager.appKey=CuKPvJQR7enquqrZ
 spring.profiles.include=oauth
-logging.level.root=info
+logging.level.root=debug
 dooray.hook.sender=https://hook.dooray.com/services/3204376758577275363/3763069957452161657/qZ0SaxauQ4GN705WHgUcaw

--- a/src/main/resources/templates/order/orders.html
+++ b/src/main/resources/templates/order/orders.html
@@ -209,11 +209,11 @@
           <th:block sec:authorize="isAnonymous()">
             <div class="p-3 border rounded-3 mb-4">
               <h4 class="fw-normal">쿠폰</h4>
-              <p class="m-auto">비회원은 쿠폰 적용이 제한됩니다.</p>
+              <p class="text-center">비회원은 쿠폰 적용이 제한됩니다.</p>
             </div>
             <div class="p-3 border rounded-3 mb-4">
               <h4 class="fw-normal">포인트 할인</h4>
-              <p class="m-autor">비회원은 쿠폰 적용이 제한됩니다.</p>
+              <p class="text-center">비회원은 포인트 할인이 제한됩니다.</p>
             </div>
           </th:block>
           <div class="p-3 border rounded-3 mb-4">
@@ -278,7 +278,7 @@
                     <span id="pay_amount" class="fw-bold">0</span>원
                   </td>
                 </tr>
-                <tr>
+                <tr sec:authorize="isAuthenticated()">
                   <th scope="col" style="font-weight: normal">예상 적립 포인트</th>
                   <td><span id="accumulate_point">0</span> P</td>
                 </tr>


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#1] 회원 등록 기능 -->

### ⛑️ 작업 내용 
1. 주문 성공 후 장바구니에서 상품을 삭제하는 부분에 오류가 있어서 수정했습니다
2. 비회원 주문 조회 경로를 변경했습니다.
3. 비회원 주문 페이지에서 적립 포인트를 보이지 않게 처리했습니다.

### ❓ 리뷰 포인트
<!-- ex) 쿼리가 너무 많이 나가는 것 같아요. -->
<!-- ex) 서비스 로직이 좀 더 가볍게 만들어야 할 것 같아요. -->

### 🧾 관련 이슈
resolves 
- #180 (이슈가 존재할 경우에만)
